### PR TITLE
Bytte javax til jakarta

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <dependencies>
         <dependency>
             <groupId>com.ibm.mq</groupId>
-            <artifactId>com.ibm.mq.allclient</artifactId>
+            <artifactId>com.ibm.mq.jakarta.client</artifactId>
             <version>9.3.0.0</version>
         </dependency>
 

--- a/src/main/java/no/nav/vedtak/felles/integrasjon/jms/ExternalQueueConsumer.java
+++ b/src/main/java/no/nav/vedtak/felles/integrasjon/jms/ExternalQueueConsumer.java
@@ -1,6 +1,6 @@
 package no.nav.vedtak.felles.integrasjon.jms;
 
-import javax.jms.JMSException;
+import jakarta.jms.JMSException;
 
 /**
  * Baseklasse for meldingsdrevne beans for "eksterne" køer (dvs. fysisk på annen MQ server enn VL bruker).

--- a/src/main/java/no/nav/vedtak/felles/integrasjon/jms/ExternalQueueProducer.java
+++ b/src/main/java/no/nav/vedtak/felles/integrasjon/jms/ExternalQueueProducer.java
@@ -1,6 +1,6 @@
 package no.nav.vedtak.felles.integrasjon.jms;
 
-import javax.jms.JMSException;
+import jakarta.jms.JMSException;
 
 /**
  * Baseklasse for sending av meldinger til "eksterne" køer (dvs. fysisk på annen MQ server enn VL bruker).</p>

--- a/src/main/java/no/nav/vedtak/felles/integrasjon/jms/InternalQueueConsumer.java
+++ b/src/main/java/no/nav/vedtak/felles/integrasjon/jms/InternalQueueConsumer.java
@@ -2,7 +2,7 @@ package no.nav.vedtak.felles.integrasjon.jms;
 
 import java.util.Enumeration;
 
-import javax.jms.JMSException;
+import jakarta.jms.JMSException;
 
 /**
  * Baseklasse for meldingsdrevne beans for "interne" køer (dvs. fysisk på samme MQ server som VL bruker).

--- a/src/main/java/no/nav/vedtak/felles/integrasjon/jms/InternalQueueProducer.java
+++ b/src/main/java/no/nav/vedtak/felles/integrasjon/jms/InternalQueueProducer.java
@@ -2,7 +2,7 @@ package no.nav.vedtak.felles.integrasjon.jms;
 
 import java.util.Enumeration;
 
-import javax.jms.JMSException;
+import jakarta.jms.JMSException;
 
 /**
  * Baseklasse for sending av meldinger til "interne" køer (dvs. fysisk på samme MQ server som VL bruker).

--- a/src/main/java/no/nav/vedtak/felles/integrasjon/jms/QueueBase.java
+++ b/src/main/java/no/nav/vedtak/felles/integrasjon/jms/QueueBase.java
@@ -2,9 +2,9 @@ package no.nav.vedtak.felles.integrasjon.jms;
 
 import java.util.Objects;
 
-import javax.jms.ConnectionFactory;
-import javax.jms.JMSContext;
-import javax.jms.Queue;
+import jakarta.jms.ConnectionFactory;
+import jakarta.jms.JMSContext;
+import jakarta.jms.Queue;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/no/nav/vedtak/felles/integrasjon/jms/QueueConsumer.java
+++ b/src/main/java/no/nav/vedtak/felles/integrasjon/jms/QueueConsumer.java
@@ -8,10 +8,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
-import javax.jms.JMSContext;
-import javax.jms.JMSException;
-import javax.jms.Message;
-import javax.jms.Queue;
+import jakarta.jms.JMSContext;
+import jakarta.jms.JMSException;
+import jakarta.jms.Message;
+import jakarta.jms.Queue;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/no/nav/vedtak/felles/integrasjon/jms/QueueProducer.java
+++ b/src/main/java/no/nav/vedtak/felles/integrasjon/jms/QueueProducer.java
@@ -2,13 +2,13 @@ package no.nav.vedtak.felles.integrasjon.jms;
 
 import java.util.function.Consumer;
 
-import javax.jms.JMSContext;
-import javax.jms.JMSException;
-import javax.jms.JMSProducer;
-import javax.jms.JMSRuntimeException;
-import javax.jms.Message;
+import jakarta.jms.JMSContext;
+import jakarta.jms.JMSException;
+import jakarta.jms.JMSProducer;
+import jakarta.jms.JMSRuntimeException;
+import jakarta.jms.Message;
 
-import com.ibm.mq.jms.MQQueue;
+import com.ibm.mq.jakarta.jms.MQQueue;
 
 import no.nav.vedtak.felles.integrasjon.jms.exception.KritiskJmsException;
 import no.nav.vedtak.felles.integrasjon.jms.pausing.MQExceptionUtil;

--- a/src/main/java/no/nav/vedtak/felles/integrasjon/jms/QueueSelftest.java
+++ b/src/main/java/no/nav/vedtak/felles/integrasjon/jms/QueueSelftest.java
@@ -1,6 +1,6 @@
 package no.nav.vedtak.felles.integrasjon.jms;
 
-import javax.jms.JMSException;
+import jakarta.jms.JMSException;
 
 /**
  * Metoder for å understøtte selftest av en meldingskø.

--- a/src/main/java/no/nav/vedtak/felles/integrasjon/jms/pausing/MQExceptionUtil.java
+++ b/src/main/java/no/nav/vedtak/felles/integrasjon/jms/pausing/MQExceptionUtil.java
@@ -1,11 +1,11 @@
 package no.nav.vedtak.felles.integrasjon.jms.pausing;
 
-import javax.jms.JMSException;
-import javax.jms.JMSRuntimeException;
+import jakarta.jms.JMSException;
+import jakarta.jms.JMSRuntimeException;
 
 import com.ibm.mq.MQException;
 import com.ibm.mq.jmqi.JmqiException;
-import com.ibm.msg.client.jms.JmsExceptionDetail;
+import com.ibm.msg.client.jakarta.jms.JmsExceptionDetail;
 
 public class MQExceptionUtil {
 

--- a/src/main/java/no/nav/vedtak/felles/integrasjon/jms/sessionmode/AutoAckSessionModeStrategy.java
+++ b/src/main/java/no/nav/vedtak/felles/integrasjon/jms/sessionmode/AutoAckSessionModeStrategy.java
@@ -1,8 +1,8 @@
 package no.nav.vedtak.felles.integrasjon.jms.sessionmode;
 
-import javax.jms.JMSContext;
-import javax.jms.Message;
-import javax.jms.Queue;
+import jakarta.jms.JMSContext;
+import jakarta.jms.Message;
+import jakarta.jms.Queue;
 
 /**
  * @deprecated TODO (rune) Denne klassen er en "last resort" hvis vi ikke får client-ack til å virke på JBoss.

--- a/src/main/java/no/nav/vedtak/felles/integrasjon/jms/sessionmode/ClientAckSessionModeStrategy.java
+++ b/src/main/java/no/nav/vedtak/felles/integrasjon/jms/sessionmode/ClientAckSessionModeStrategy.java
@@ -1,8 +1,8 @@
 package no.nav.vedtak.felles.integrasjon.jms.sessionmode;
 
-import javax.jms.JMSContext;
-import javax.jms.Message;
-import javax.jms.Queue;
+import jakarta.jms.JMSContext;
+import jakarta.jms.Message;
+import jakarta.jms.Queue;
 
 public class ClientAckSessionModeStrategy implements SessionModeStrategy {
 

--- a/src/main/java/no/nav/vedtak/felles/integrasjon/jms/sessionmode/SessionModeStrategy.java
+++ b/src/main/java/no/nav/vedtak/felles/integrasjon/jms/sessionmode/SessionModeStrategy.java
@@ -1,8 +1,8 @@
 package no.nav.vedtak.felles.integrasjon.jms.sessionmode;
 
-import javax.jms.JMSContext;
-import javax.jms.Message;
-import javax.jms.Queue;
+import jakarta.jms.JMSContext;
+import jakarta.jms.Message;
+import jakarta.jms.Queue;
 
 /**
  * Strategi for commit / rollback av meldinger man lykkes / ikke lykkes å prosessere.

--- a/src/test/java/no/nav/vedtak/felles/integrasjon/jms/ExternalSelftestQueueProducerTest.java
+++ b/src/test/java/no/nav/vedtak/felles/integrasjon/jms/ExternalSelftestQueueProducerTest.java
@@ -7,16 +7,16 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import javax.jms.Connection;
-import javax.jms.JMSConsumer;
-import javax.jms.JMSContext;
-import javax.jms.JMSException;
-import javax.jms.JMSProducer;
-import javax.jms.MessageProducer;
-import javax.jms.Queue;
-import javax.jms.QueueBrowser;
-import javax.jms.Session;
-import javax.jms.TextMessage;
+import jakarta.jms.Connection;
+import jakarta.jms.JMSConsumer;
+import jakarta.jms.JMSContext;
+import jakarta.jms.JMSException;
+import jakarta.jms.JMSProducer;
+import jakarta.jms.MessageProducer;
+import jakarta.jms.Queue;
+import jakarta.jms.QueueBrowser;
+import jakarta.jms.Session;
+import jakarta.jms.TextMessage;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/no/nav/vedtak/felles/integrasjon/jms/InternalSelftestQueueProducerTest.java
+++ b/src/test/java/no/nav/vedtak/felles/integrasjon/jms/InternalSelftestQueueProducerTest.java
@@ -6,13 +6,13 @@ import static org.mockito.Mockito.when;
 
 import java.util.Enumeration;
 
-import javax.jms.JMSConsumer;
-import javax.jms.JMSContext;
-import javax.jms.JMSException;
-import javax.jms.JMSProducer;
-import javax.jms.Queue;
-import javax.jms.QueueBrowser;
-import javax.jms.TextMessage;
+import jakarta.jms.JMSConsumer;
+import jakarta.jms.JMSContext;
+import jakarta.jms.JMSException;
+import jakarta.jms.JMSProducer;
+import jakarta.jms.Queue;
+import jakarta.jms.QueueBrowser;
+import jakarta.jms.TextMessage;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/no/nav/vedtak/felles/integrasjon/jms/QueueConsumerTest.java
+++ b/src/test/java/no/nav/vedtak/felles/integrasjon/jms/QueueConsumerTest.java
@@ -14,15 +14,15 @@ import static org.mockito.Mockito.when;
 import java.util.Enumeration;
 import java.util.concurrent.TimeUnit;
 
-import javax.jms.JMSConsumer;
-import javax.jms.JMSContext;
-import javax.jms.JMSException;
-import javax.jms.JMSProducer;
-import javax.jms.JMSRuntimeException;
-import javax.jms.Message;
-import javax.jms.Queue;
-import javax.jms.QueueBrowser;
-import javax.jms.TextMessage;
+import jakarta.jms.JMSConsumer;
+import jakarta.jms.JMSContext;
+import jakarta.jms.JMSException;
+import jakarta.jms.JMSProducer;
+import jakarta.jms.JMSRuntimeException;
+import jakarta.jms.Message;
+import jakarta.jms.Queue;
+import jakarta.jms.QueueBrowser;
+import jakarta.jms.TextMessage;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/no/nav/vedtak/felles/integrasjon/jms/sessionmode/ClientAckSessionModeStrategyTest.java
+++ b/src/test/java/no/nav/vedtak/felles/integrasjon/jms/sessionmode/ClientAckSessionModeStrategyTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import javax.jms.JMSContext;
+import jakarta.jms.JMSContext;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
Tar inn com.ibm.mq.jakarta.client isf allclient
Endring med com.ibm.mq.jakarta.jms og com.ibm.msg.client.jakarta.jms i QueueProducer og MQExceptionUtil
Bytte javax.jms med jakarta.jms

Korteste vei til validering er kanskje k9-oppdrag ?